### PR TITLE
Write valid composer.json

### DIFF
--- a/Classes/Command/DumpComposerCommand.php
+++ b/Classes/Command/DumpComposerCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Sypets\Migrate2composer\Composer\ComposerUtility;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Core\Package\PackageManager;
@@ -194,8 +195,7 @@ class DumpComposerCommand extends Command
             if (!$batchMode) {
                 $io->section('composer.json');
             }
-            $io->writeln(\json_encode($composerManifest,
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_LINE_TERMINATORS | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            $io->writeln(ComposerUtility::convertComposerArrayToString($composerManifest));
         }
 
         // show errors

--- a/Classes/Composer/ComposerUtility.php
+++ b/Classes/Composer/ComposerUtility.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sypets\Migrate2composer\Composer;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class ComposerUtility
+{
+    /**
+     * This function removes empty arrays from an array.
+     * Empty arrays may cause problems when writing composer.json
+     * because they may be objects (associative arrays) or arrays
+     * (numbered arrays). If they are empty, we cannot determine
+     * the type and then the incorrect type may get used.
+     *
+     * @param array $a
+     * @return void
+     */
+    public static function removeEmptyArrays(array &$a) : void
+    {
+        if (!$a || !is_array($a)) {
+            return;
+        }
+
+        foreach ($a as $key => $value) {
+            if (is_array($value) && !empty($value)) {
+                self::removeEmptyArrays($value);
+            }
+            if (is_array($value) && empty($value)) {
+                unset($a[$key]);
+                continue;
+            }
+        }
+    }
+
+    /**
+     * Return an array into a string that can be written as composer.json
+     *
+     * @param array $input
+     * @return string
+     */
+    public static function convertComposerArrayToString(array $input) : string
+    {
+        // normalize array
+        self::removeEmptyArrays($input);
+        return \json_encode($input,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_LINE_TERMINATORS | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+}

--- a/Resources/Private/Composer/composer.json
+++ b/Resources/Private/Composer/composer.json
@@ -1,32 +1,35 @@
 {
-  "name": "Add name ...",
-  "description": "Add description ...",
-  "authors": {
-    "name": "Author name",
-    "email": "nouser@example.com"
-  },
-  "repositories": {},
-  "require": {},
-  "autoload": {
-    "psr-4": {},
-    "classmap": {}
-  },
-  "config": {
-    "platform": {},
-    "sort-packages": true
-  },
-  "extra": {
-    "typo3/cms": {
-      "web-dir": "public"
-    }
-  },
-  "scripts":{
-    "typo3-cms-scripts": [
-      "typo3cms install:fixfolderstructure",
-      "typo3cms install:generatepackagestates"
-    ],
-    "post-autoload-dump": [
-      "@typo3-cms-scripts"
-    ]
-  }
+	"name": "vendor/mysite",
+	"description": "Add description ...",
+	"license": ["GPL-2.0-or-later"],
+	"authors": [
+		{
+			"name": "Author name",
+			"email": "nouser@example.com"
+		}
+	],
+	"repositories": {},
+	"require": {},
+	"autoload": {
+		"psr-4": {},
+		"classmap": []
+	},
+	"config": {
+		"platform": {},
+		"sort-packages": true
+	},
+	"extra": {
+		"typo3/cms": {
+			"web-dir": "public"
+		}
+	},
+	"scripts": {
+		"typo3-cms-scripts": [
+			"typo3cms install:fixfolderstructure",
+			"typo3cms install:generatepackagestates"
+		],
+		"post-autoload-dump": [
+			"@typo3-cms-scripts"
+		]
+	}
 }


### PR DESCRIPTION
- Fix some errors in composer.json template
- Remove empty arrays before writing composer.json. Otherwise they
  may not have the correct type (object or array). Also this ensures
  a clean and less cluttered composer.json file.

Resolves: #1
Releases: master, 8.7