### PR TITLE
[BUGFIX] Remove php from scripts section

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+9.5.6
+=====
+
+Remove php from scripts section
+
+The scripts section should use the command as used in the
+typo3/cms-base-distribution package composer.json.
+
+
 9.5.5
 =====
 

--- a/Resources/Private/Composer/composer.json
+++ b/Resources/Private/Composer/composer.json
@@ -30,8 +30,8 @@
 	},
 	"scripts": {
 		"typo3-cms-scripts": [
-			"php typo3cms install:generatepackagestates",
-			"php typo3cms install:fixfolderstructure"
+			"typo3cms install:generatepackagestates",
+			"typo3cms install:fixfolderstructure"
 		],
 		"post-autoload-dump": [
 			"@typo3-cms-scripts"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'uploadfolder' => '0',
     'createDirs' => '',
     'clearCacheOnLoad' => 0,
-    'version' => '9.5.5',
+    'version' => '9.5.6',
     'constraints' => [
         'depends' => [
             'typo3' => '9.5.9-9.5.999'
@@ -21,7 +21,4 @@ $EM_CONF[$_EXTKEY] = [
         'suggests' => [],
     ],
 ];
-
-
-
 


### PR DESCRIPTION
The scripts section should use the command as used in the
typo3/cms-base-distribution package composer.json.

Resolves: #6